### PR TITLE
Fix CLI debug flag and constructor options

### DIFF
--- a/sigils/__main__.py
+++ b/sigils/__main__.py
@@ -108,7 +108,7 @@ def main():
             process_file(args.file, output_path, context, args.debug)
     else:
         text = args.text if not args.expression else f"{args.text}%[{args.expression}]"
-        result = Sigil(text, debug=debug) % context
+        result = Sigil(text, debug=args.debug) % context
         print(result)
     
     

--- a/sigils/sigil.py
+++ b/sigils/sigil.py
@@ -32,8 +32,8 @@ class Sigil:
         self.template = template
 
         # Use instance-specific values or fall back to class defaults
-        self.executable = executable if brackets is not None else self.__class__.executable
-        self.brackets = brackets if executable is not None else self.__class__.brackets
+        self.executable = executable if executable is not None else self.__class__.executable
+        self.brackets = brackets if brackets is not None else self.__class__.brackets
         self.max_depth = max_depth if max_depth is not None else self.__class__.max_depth
         self.debug = debug if debug is not None else self.__class__.debug
         self.on_error = on_error if on_error is not None else self.__class__.on_error

--- a/sigils/tests.py
+++ b/sigils/tests.py
@@ -1,5 +1,12 @@
 import os
+import sys
+import json
+import tempfile
 import unittest
+import io
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
 from sigils import Sigil
 
 
@@ -29,7 +36,15 @@ class TestSigil(unittest.TestCase):
 
     def test_custom_debug_false_flag_gets_unset(self):
         s = Sigil("Hello, %[name]!", debug=False)
-        self.assertFalse(s.debug)  
+        self.assertFalse(s.debug)
+
+    def test_custom_executable_flag_gets_set(self):
+        s = Sigil("Hello, %[name]!", executable=False)
+        self.assertFalse(s.executable)
+
+    def test_custom_brackets_gets_set(self):
+        s = Sigil("Hello, %{name}", brackets=["%{", "}"])
+        self.assertEqual(s.brackets, ["%{", "}"])
 
     def test_basic_solve(self):
         s = Sigil("Hello, %[name]!")
@@ -133,6 +148,24 @@ class TestSigil(unittest.TestCase):
         # Keep at least one example, since this is the most common use case
         s = Sigil("Hello!")
         self.assertEqual(s % None, "Hello!")
+
+    def test_cli_main_runs(self):
+        with tempfile.NamedTemporaryFile("w", suffix=".json", delete=False) as tmp:
+            json.dump({"name": "Alice"}, tmp)
+            tmp.flush()
+            args = [
+                "sigils",
+                "Hello, %[name]!",
+                "--context",
+                tmp.name,
+            ]
+            with patch.object(sys, "argv", args):
+                with io.StringIO() as buf, redirect_stdout(buf):
+                    from sigils.__main__ import main
+                    main()
+                    output = buf.getvalue().strip()
+        os.unlink(tmp.name)
+        self.assertEqual(output, "Hello, Alice!")
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- fix CLI NameError by using args.debug
- correct Sigil constructor to respect executable and bracket parameters
- add tests for CLI invocation and configurable options

## Testing
- `python -m unittest sigils.tests -v`


------
https://chatgpt.com/codex/tasks/task_e_68c0efe739188326bb26df6c51bc7d89