### PR TITLE
Allow optional percent delimiters around sigils

### DIFF
--- a/sigils/sigil.py
+++ b/sigils/sigil.py
@@ -29,7 +29,7 @@ class Sigil:
 
         self.pattern = getattr(self.cache, 'value', {}).get(template)
         if self.pattern is None:
-            self.pattern = re.compile(r'%\[(.*?)\]')
+            self.pattern = re.compile(r'%?\[(.*?)\]%?')
             self.cache.value = {template: self.pattern}
 
     def solve(self, context=None, sep="|"):

--- a/tests/test_sigils.py
+++ b/tests/test_sigils.py
@@ -55,6 +55,12 @@ class TestSigil(unittest.TestCase):
         s = Sigil("%[callable_with_args %name]")
         self.assertEqual(s % self.context, "Hello, name!")
 
+    def test_optional_percent_delimiters(self):
+        self.assertEqual(Sigil("[name]") % self.context, "Alice")
+        self.assertEqual(Sigil("%[name]") % self.context, "Alice")
+        self.assertEqual(Sigil("[name]%") % self.context, "Alice")
+        self.assertEqual(Sigil("%[name]%") % self.context, "Alice")
+
     def test_literal_on_unsolved_just_removes_brackets(self):
         s = Sigil("%[notfound]")
         self.assertEqual(s % self.context, "notfound")


### PR DESCRIPTION
## Summary
- allow sigil parsing to accept templates with optional leading and trailing percent delimiters
- add regression coverage for each delimiter combination

## Testing
- PYTHONPATH=. pytest tests/test_sigils.py

------
https://chatgpt.com/codex/tasks/task_e_68ffd01cca548326a0b5557b7f08dd9a